### PR TITLE
JSDoc support on const declarations (for typing using JSDoc)

### DIFF
--- a/plugins/org.eclipse.dltk.javascript.parser/src/org/eclipse/dltk/javascript/ast/ConstStatement.java
+++ b/plugins/org.eclipse.dltk.javascript.parser/src/org/eclipse/dltk/javascript/ast/ConstStatement.java
@@ -19,10 +19,11 @@ import org.eclipse.dltk.ast.ASTNode;
 import org.eclipse.dltk.ast.ASTVisitor;
 import org.eclipse.dltk.javascript.internal.parser.JSLiterals;
 
-public class ConstStatement extends Statement implements IVariableStatement {
+public class ConstStatement extends Statement implements IVariableStatement, Documentable {
 
 	private Keyword constKeyword;
 	private final List<VariableDeclaration> consts = new ArrayList<VariableDeclaration>();
+	private Comment documentation;
 	private int semic = -1;
 
 	public ConstStatement(JSNode parent) {
@@ -90,6 +91,15 @@ public class ConstStatement extends Statement implements IVariableStatement {
 		buffer.append(";\n");
 
 		return buffer.toString();
+	}
+
+	@Override
+	public Comment getDocumentation() {
+		return documentation;
+	}
+
+	public void setDocumentation(Comment documentation) {
+		this.documentation = documentation;
 	}
 
 }

--- a/plugins/org.eclipse.dltk.javascript.parser/src/org/eclipse/dltk/javascript/parser/JSTransformer.java
+++ b/plugins/org.eclipse.dltk.javascript.parser/src/org/eclipse/dltk/javascript/parser/JSTransformer.java
@@ -2098,6 +2098,7 @@ public class JSTransformer {
 
 	protected ASTNode visitConst(Tree node) {
 		ConstStatement declaration = new ConstStatement(getParent());
+		locateDocumentation(declaration, node);
 		declaration.setConstKeyword(createKeyword(node, Keywords.CONST));
 
 		processVariableDeclarations(node, declaration, SymbolKind.CONST);


### PR DESCRIPTION
Currently the @type tag in JSDoc on const declarations doesn't do anything, because ConstDeclaration does't implement Documentatble